### PR TITLE
fix: remove stale package entry fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "bin": {
     "heading-case": "./bin.js"
   },
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

This PR removes the stale `module` field from `package.json` because the package already uses `exports` to define its public entry points. The removed `module` field pointed to `dist/index.mjs`, which is not included in the published package.